### PR TITLE
Parallelise docker_bot using concurrency

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,8 +79,8 @@ You will need to restart the terminal for the second command to take effect.
 ## :children_crossing: Usage
 
 ```bash
-usage: docker-bot [-h] [-a MAX_AGE] [-l LIMIT] [--identity] [--dry-run]
-                  [--purge] [-v]
+usage: docker-bot [-h] [-a MAX_AGE] [-l LIMIT] [-t THREADS] [--identity]
+                  [--dry-run] [--purge] [-v]
                   name
 
 Script to clean old Docker images out of an Azure Container Registry (ACR)
@@ -96,6 +96,8 @@ optional arguments:
   -l LIMIT, --limit LIMIT
                         Maximum size in TB the ACR is allowed to grow to.
                         Default: 2 TB.
+  -t THREADS, --threads THREADS
+                        Number of threads to parallelise over
   --identity            Login to Azure with a Managed System Identity
   --dry-run             Do a dry-run, no images will be deleted.
   --purge               Purge all repositories within the ACR

--- a/docker_bot/__init__.py
+++ b/docker_bot/__init__.py
@@ -7,7 +7,7 @@ from .app import (
     login,
     pull_repos,
     pull_manifests,
-    pull_image_size,
+    pull_image_age,
     sort_image_df,
     run,
 )

--- a/docker_bot/__init__.py
+++ b/docker_bot/__init__.py
@@ -8,6 +8,7 @@ from .app import (
     pull_repos,
     pull_manifests,
     pull_image_age,
+    purge_all,
     sort_image_df,
     run,
 )

--- a/docker_bot/app.py
+++ b/docker_bot/app.py
@@ -177,7 +177,6 @@ def pull_image_age(acr_name: str, manifest: dict) -> Tuple[str, int]:
     return (
         f"{manifest['repo']}@{manifest['digest']}",
         diff,
-        int(result["output"]) * 1.0e-9,
     )
 
 
@@ -325,10 +324,7 @@ def run(
                 image_name, ages_days = future
 
                 image_df = image_df.append(
-                    {
-                        "image_name": image_name,
-                        "age_days": age_days,
-                    },
+                    {"image_name": image_name, "age_days": age_days,},
                     ignore_index=True,
                 )
 

--- a/docker_bot/app.py
+++ b/docker_bot/app.py
@@ -330,7 +330,7 @@ def run(
                 for repo in repos
             ]
 
-            for cases in futures:
+            for cases in as_completed(futures):
                 for case in cases:
                     manifests.update(case)
 
@@ -344,7 +344,7 @@ def run(
                 for manifest in manifests
             ]
 
-            for future in futures:
+            for future in as_completed(futures):
                 image_name, ages_days, image_size = future
 
                 image_df = image_df.append(

--- a/docker_bot/app.py
+++ b/docker_bot/app.py
@@ -2,7 +2,6 @@ import sys
 import json
 import logging
 import datetime
-import itertools
 import pandas as pd
 from typing import Tuple
 from .helper_functions import run_cmd
@@ -254,7 +253,7 @@ def purge_all(acr_name: str, df: pd.DataFrame) -> None:
         result = run_cmd(delete_cmd)
 
         if result["returncode"] != 0:
-            logger.erro(result["err_msg"])
+            logger.error(result["err_msg"])
             raise RuntimeError(result["err_msg"])
 
 

--- a/docker_bot/app.py
+++ b/docker_bot/app.py
@@ -324,7 +324,7 @@ def run(
                 image_name, ages_days = future
 
                 image_df = image_df.append(
-                    {"image_name": image_name, "age_days": age_days,},
+                    {"image_name": image_name, "age_days": age_days},
                     ignore_index=True,
                 )
 

--- a/docker_bot/cli.py
+++ b/docker_bot/cli.py
@@ -43,7 +43,7 @@ def parse_args(args):
     )
     parser.add_argument(
         "-t",
-        "--thread",
+        "--threads",
         type=int,
         default=1,
         help="Number of threads to parallelise over",
@@ -96,6 +96,7 @@ def main():
         args.name,
         args.max_age,
         args.limit,
+        args.threads,
         dry_run=args.dry_run,
         purge=args.purge,
         identity=args.identity,

--- a/docker_bot/cli.py
+++ b/docker_bot/cli.py
@@ -1,6 +1,7 @@
 import sys
 import argparse
 from .app import run
+from multiprocessing import cpu_count
 
 
 def logging_config(verbose: bool = False) -> None:
@@ -73,6 +74,15 @@ def parse_args(args):
 def check_parser(args):
     if args.dry_run and args.purge:
         raise ValueError("purge and dry-run options cannot be used together")
+
+    if args.threads != 1:
+        cpus = cpu_count()
+        if args.threads > cpus:
+            raise ValueError(
+                "You have requested more threads than are available cores on this machine.\n"
+                f"This machine has {cpus} CPUs available.\n"
+                "Please adjust the value of --threads accordingly."
+            )
 
 
 def main():

--- a/docker_bot/cli.py
+++ b/docker_bot/cli.py
@@ -40,6 +40,13 @@ def parse_args(args):
         default=2.0,
         help="Maximum size in TB the ACR is allowed to grow to. Default: 2 TB.",
     )
+    parser.add_argument(
+        "-t",
+        "--thread",
+        type=int,
+        default=1,
+        help="Number of threads to parallelise over",
+    )
 
     parser.add_argument(
         "--identity",

--- a/docker_bot/cli.py
+++ b/docker_bot/cli.py
@@ -1,4 +1,5 @@
 import sys
+import logging
 import argparse
 from .app import run
 from multiprocessing import cpu_count

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -460,7 +460,7 @@ def test_purge_all(mock_args):
     "docker_bot.app.run_cmd",
     return_value={"returncode": 1, "err_msg": "Could not run command"},
 )
-def test_purge_all(mock_args):
+def test_purge_all_exception(mock_args):
     acr_name = "test_acr"
     test_df = pd.DataFrame(
         {"image_name": ["image1", "image2"], "age_days": [67, 53]}

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -9,7 +9,7 @@ from docker_bot.app import (
     delete_image,
     login,
     pull_manifests,
-    pull_image_size,
+    pull_image_age,
     pull_repos,
     sort_image_df,
 )
@@ -185,7 +185,7 @@ def test_pull_manifests_exception(mock_args):
         assert mock.return_value["err_msg"] == "Could not run command"
 
 
-def test_pull_image_size():
+def test_pull_image_age():
     acr_name = "test_acr"
     repo = "test_repo"
     manifest = {
@@ -194,76 +194,11 @@ def test_pull_image_size():
         "repo": "test_repo",
     }
 
-    mock_run = patch(
-        "docker_bot.app.run_cmd",
-        return_value={"returncode": 0, "output": "1000000000"},
-    )
+    with freeze_time("2020-08-01T09:30:00.0000000Z"):
+        out = pull_image_age(acr_name, manifest)
 
-    with mock_run as mock, freeze_time("2020-08-01T09:30:00.0000000Z"):
-        out = pull_image_size(acr_name, manifest)
-
-        mock.assert_called_once()
-        mock.assert_called_once_with(
-            [
-                "az",
-                "acr",
-                "repository",
-                "show",
-                "-n",
-                acr_name,
-                "--imag",
-                f"{repo}@{manifest['digest']}",
-                "--query",
-                "imageSize",
-                "-o",
-                "tsv",
-            ]
-        )
-        assert mock.return_value == {"returncode": 0, "output": "1000000000"}
         assert out[0] == f"{repo}@{manifest['digest']}"
         assert out[1] == 1
-        assert out[2] == 1.0
-
-
-def test_pull_image_size_exception():
-    acr_name = "test_acr"
-    manifest = {
-        "timestamp": "2020-07-30T21:12:00.0000000Z",
-        "digest": "image_digest",
-        "repo": "test_repo",
-    }
-
-    mock_run = patch(
-        "docker_bot.app.run_cmd",
-        return_value={"returncode": 1, "err_msg": "Could not run command"},
-    )
-
-    with mock_run as mock, freeze_time(
-        "2020-08-01T09:30:00.0000000Z"
-    ), pytest.raises(RuntimeError):
-        pull_image_size(acr_name, manifest)
-
-        mock.assert_called_once()
-        mock.assert_called_once_with(
-            [
-                "az",
-                "acr",
-                "repository",
-                "show",
-                "-n",
-                acr_name,
-                "--imag",
-                f"{repo}@{manifest['digest']}",
-                "--query",
-                "imageSize",
-                "-o",
-                "tsv",
-            ]
-        )
-        assert mock.return_value == {
-            "returncode": 1,
-            "err_msg": "Could not run command",
-        }
 
 
 @patch(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -33,7 +33,9 @@ def test_check_parser_alternate_values():
 
 @patch(
     "argparse.ArgumentParser.parse_args",
-    return_value=argparse.Namespace(name="test_acr", max_age=90, limit=2.0,),
+    return_value=argparse.Namespace(
+        name="test_acr", max_age=90, limit=2.0, threads=1
+    ),
 )
 def test_parser_run_basic(mock_args):
     parser = parse_args("test_acr")
@@ -41,6 +43,7 @@ def test_parser_run_basic(mock_args):
     assert parser.name == "test_acr"
     assert parser.max_age == 90
     assert parser.limit == 2.0
+    assert parser.threads == 1
     assert mock_args.call_count == 1
 
 
@@ -65,7 +68,9 @@ def test_parser_run_boolean(mock_args):
 
 @patch(
     "argparse.ArgumentParser.parse_args",
-    return_value=argparse.Namespace(name="test_acr", max_age=10, limit=1.5),
+    return_value=argparse.Namespace(
+        name="test_acr", max_age=10, limit=1.5, threads=4
+    ),
 )
 def test_parser_run_options(mock_args):
     parser = parse_args(["test_acr", "--max-age", 10, "--limit", 1.5])
@@ -73,4 +78,5 @@ def test_parser_run_options(mock_args):
     assert parser.name == "test_acr"
     assert parser.max_age == 10
     assert parser.limit == 1.5
+    assert parser.threads == 4
     assert mock_args.call_count == 1

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -12,7 +12,7 @@ def test_check_parser():
 
 
 def test_check_parser_both_false():
-    test_args = argparse.Namespace(dry_run=False, purge=False)
+    test_args = argparse.Namespace(dry_run=False, purge=False, threads=1)
 
     try:
         check_parser(test_args)
@@ -21,14 +21,24 @@ def test_check_parser_both_false():
 
 
 def test_check_parser_alternate_values():
-    test_args1 = argparse.Namespace(dry_run=True, purge=False)
-    test_args2 = argparse.Namespace(dry_run=False, purge=True)
+    test_args1 = argparse.Namespace(dry_run=True, purge=False, threads=1)
+    test_args2 = argparse.Namespace(dry_run=False, purge=True, threads=1)
 
     try:
         check_parser(test_args1)
         check_parser(test_args2)
     except:  # noqa: E722
         pytest.fail("Unexpected error")
+
+
+@patch("docker_bot.cli.cpu_count", return_value=4)
+def test_check_parser_threads(mock_args):
+    test_args = argparse.Namespace(dry_run=True, purge=False, threads=5)
+
+    with pytest.raises(ValueError):
+        check_parser(test_args)
+        assert mock_args.call_count == 1
+        assert mock_args.return_value == 4
 
 
 @patch(


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request!

Don't worry, these HTML comments won't render in your issue.
Feel free to delete them once you've read them :) -->

### Summary
<!-- Please describe the purpose of this PR.
Is it fixing a bug or adding a feature?

Please reference relevant issue numbers with action words to close them if relevant. -->

This PR parallelises calls to the Azure Container Registry using concurrency.

fix #21

### What's changed?
<!-- You can use this section to go into more detail about what's changed.
We recommend using bullet points. -->

- Calls to `pull_manifest`, `pull_image_age` and `delete_image` are now parallelised
- New `--threads` argument in the CLI
- Updated tests

### What should a reviewer concetrate their feedback on?
<!-- You can use this section to request specific feedback.
We recommend using check boxes. -->

- [x] Everything looks ok?
